### PR TITLE
[G2M] list - update list item selected colour to primary color

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ typings/
 
 # DynamoDB Local files
 .dynamodb/
+
+# vscode
+.vscode/

--- a/src/list/list-item.js
+++ b/src/list/list-item.js
@@ -63,10 +63,10 @@ const useStyles = makeStyles((theme) => {
       height: theme.spacing(7),
       marginRight: theme.spacing(0.5),
     },
-    spacing: (num) => ({
+    spacing: ({ spacing }) => ({
       border: `1px solid ${theme.palette.secondary[300]}`,
       borderRadius: theme.spacing(0.5),
-      marginBottom: theme.spacing(num),
+      marginBottom: theme.spacing(spacing),
     }),
     complete: {
       color: theme.palette.success.main,
@@ -89,6 +89,10 @@ const useStyles = makeStyles((theme) => {
       fontSize: '12px',
       marginTop: theme.spacing(0.7),
     },
+    selected: ({ selectedColor, fontColor }) => ({
+      backgroundColor: `${selectedColor} !important`,
+      color: `${fontColor} !important`,
+    }),
   }
 })
 
@@ -118,8 +122,10 @@ const ListItem = ({
   chip,
   chipColor,
   chipProps,
+  selectedColor,
+  fontColor,
 }) => {
-  const classes = useStyles(spacing)
+  const classes = useStyles({ spacing, selectedColor, fontColor })
   const [open, setOpen] = useState(false)
   const showDetails = () => setOpen(!open)
   const buttonProps = button && { disableRipple: true }
@@ -199,6 +205,7 @@ const ListItem = ({
           [classes.root]: true,
           [classes.notSelected]: focusOnSelected && !selected,
           [classes.backgroundColor]: open,
+          [classes.selected]: selected && classes.selected,
         })}
       >
         {!avatar && expand !== 'end' && renderIconButton()}
@@ -288,6 +295,8 @@ ListItem.propTypes = {
   chip: PropTypes.string,
   chipColor: PropTypes.string,
   chipProps: PropTypes.object,
+  selectedColor: PropTypes.string,
+  fontColor: PropTypes.string,
 }
 
 ListItem.defaultProps = {
@@ -311,6 +320,8 @@ ListItem.defaultProps = {
   chip: '',
   propColor: '',
   chipProps: {},
+  selectedColor: '',
+  fontColor: '',
 }
 
 export default ListItem

--- a/stories/list.stories.js
+++ b/stories/list.stories.js
@@ -110,6 +110,7 @@ const leftData = defaultData.map((item, i) => {
     avatarSize: 'sm',
     avatarBgColor: 'inherit',
     details: '',
+    selectedColor: '#BAE0FF',
   }
   return newItem
 })


### PR DESCRIPTION
Add selected colour and font colour as props so when people use the `list` component as a clickable button, they can choose a different colour. 
The idea of this change comes to the home page's recent activities. 

Before:
![image](https://user-images.githubusercontent.com/20359409/88852630-872ab000-d1bc-11ea-983e-2e4b0e8cb055.png)

The grey is often used in disable. That's the reason why I feel change it to our primary colour will make users feel it's clickable.

After change:
![image](https://user-images.githubusercontent.com/20359409/88852859-dec91b80-d1bc-11ea-9c37-fbca0bfee99f.png)

Note:
The index of the list item is not changeable in the `list-item.js`, in the example, it's defined in the [list.stories.js](https://github.com/EQWorks/react-labs/blob/8318c50ed6e3708123829b0b7dae715eae9ab990/stories/list.stories.js#L153)