### PR TITLE
[G2M] table - lighter no remember key, fix per-col initial hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `<Tabe />` - lighter impl on unspecified `remember.key` prop
+
 ## [1.7.2] - 2020-08-07
 ### Fixed
 - `<Table />` - table can now update based on dinamically sortBy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `<Tabe />` - lighter impl on unspecified `remember.key` prop
 
+### Fixed
+- `<Table />` - per-column initial hidden state on no-accessor columns
+
 ## [1.7.2] - 2020-08-07
 ### Fixed
 - `<Table />` - table can now update based on dinamically sortBy

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react-slick": "^0.26.1",
     "react-table": "^7.1.0",
     "slick-carousel": "^1.8.1",
-    "use-cached": "^1.2.1"
+    "use-cached": "^2.0.0"
   },
   "scripts": {
     "test": "yarn jest --testPathPattern=__tests__/",

--- a/src/table/index.js
+++ b/src/table/index.js
@@ -68,7 +68,7 @@ const useTableConfig = ({ data, hiddenColumns, children, columns, remember }) =>
     ...remember,
     key: remember.key != null ? `${remember.key}_HIDDEN` : null,
   })(useState)(() => {
-    const _hidden = _cols.filter((c) => c.hidden).map((c) => typeof c.accessor === 'function' ? c.id : c.accessor)
+    const _hidden = _cols.filter((c) => c.hidden).map((c) => (typeof c.accessor === 'string') ? c.accessor : c.id)
     return _hidden.length ? _hidden : (hiddenColumns || [])
   })
 

--- a/src/table/index.js
+++ b/src/table/index.js
@@ -64,11 +64,10 @@ const useTableConfig = ({ data, hiddenColumns, children, columns, remember }) =>
         .map((c) => c.props)
   }, [columns, data, children])
   // cached hidden state
-  const [
-    hidden,
-    setHiddenCache,
-    removeHiddenCache,
-  ] = cached({ ...remember, key: `${remember.key}_HIDDEN` })(useState)(() => {
+  const [hidden, setHiddenCache] = cached({
+    ...remember,
+    key: remember.key != null ? `${remember.key}_HIDDEN` : null,
+  })(useState)(() => {
     const _hidden = _cols.filter((c) => c.hidden).map((c) => typeof c.accessor === 'function' ? c.id : c.accessor)
     return _hidden.length ? _hidden : (hiddenColumns || [])
   })
@@ -78,7 +77,6 @@ const useTableConfig = ({ data, hiddenColumns, children, columns, remember }) =>
     _data,
     hidden,
     setHiddenCache,
-    removeHiddenCache,
   }
 }
 
@@ -100,14 +98,12 @@ const Table = ({
     _data,
     hidden,
     setHiddenCache,
-    removeHiddenCache,
   } = useTableConfig({ data, hiddenColumns, children, columns, remember })
   // remember me
-  const [
-    cachedSortBy,
-    setCachedSortBy,
-    removeCachedSortBy,
-  ] = cached({ ...remember, key: `${remember.key}_SORT_BY` })(useState)(sortBy)
+  const [cachedSortBy, setCachedSortBy] = cached({
+    ...remember,
+    key: remember.key != null ? `${remember.key}_SORT_BY` : null,
+  })(useState)(sortBy)
   // useTable
   const {
     getTableProps,
@@ -145,21 +141,11 @@ const Table = ({
     if (remember.hidden) {
       setHiddenCache(_hidden)
     }
-    return () => {
-      if (!remember.hidden) {
-        removeHiddenCache()
-      }
-    }
   }, [_hidden, remember.hidden])
   // remember sortBy
   useEffect(() => {
     if (remember.sortBy) {
       setCachedSortBy(_sortBy)
-    }
-    return () => {
-      if (!remember.sortBy) {
-        removeCachedSortBy()
-      }
     }
   }, [_sortBy, remember.sortBy])
   useEffect(() => {
@@ -277,7 +263,7 @@ Table.propTypes = {
   headerGroupProps: PropTypes.object,
   sortBy: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.object]),
   remember: PropTypes.shape({
-    key: PropTypes.string.isRequired,
+    key: PropTypes.string,
     ttl: PropTypes.number,
     ttlMS: PropTypes.number,
     hidden: PropTypes.bool,
@@ -293,9 +279,7 @@ Table.defaultProps = {
   tableProps: {},
   headerGroupProps: {},
   sortBy: {},
-  remember: {
-    key: '__not_cached',
-  },
+  remember: {},
 }
 Table.Column = TableColumn
 Table.filters = { DefaultFilter, SelectionFilter, RangeFilter }

--- a/stories/table.stories.js
+++ b/stories/table.stories.js
@@ -111,16 +111,19 @@ export const initialHidden = () => (
       { Header: 'Total cases', accessor: 'total_cases' },
       { Header: 'Province', accessor: 'province', hidden: true, noToggle: true },
       { Header: 'Rate', accessor: 'rate', Cell: ({ value }) => `${value}%` },
+      // eslint-disable-next-line react/display-name
+      { Header: 'Action', id: 'action', Cell: () => (<button onClick={null}>Edit</button>), hidden: true },
     ]}
   />
 )
 
 export const initialHiddenColumns = () => (
-  <Table data={provinces} hiddenColumns={['new_cases', 'total_cases']}>
+  <Table data={provinces} hiddenColumns={['new_cases', 'total_cases', 'action']}>
     <Table.Column Header='New cases' accessor='new_cases' />
     <Table.Column Header='Total cases' accessor='total_cases' />
     <Table.Column Header='Province' accessor='province' />
     <Table.Column Header='Rate' accessor='rate' Cell={({ value }) => `${value}%`} />
+    <Table.Column Header='Action' id='action' Cell={() => (<button onClick={null}>Edit</button>)} />
   </Table>
 )
 
@@ -288,11 +291,11 @@ export const rememberSortBy = () => {
 }
 export const dynamicSortBy = () => {
   const [sort, setSort] = useState('province')
-  
+
   return (
     <>
       <Typography variant='body1'>
-        SortBy changing according to the chosen button. 
+        SortBy changing according to the chosen button.
       </Typography>
       {['new_cases', 'total_cases', 'province'].map(col => (
         <button key= {col} onClick={() => setSort(col)} > {col} </button>))}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10714,10 +10714,10 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-cached@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/use-cached/-/use-cached-1.2.1.tgz#6ee65e01328521dd2be30dd5547bd03013117730"
-  integrity sha512-V4Nst4OA9rSkHw3H6i+U8WcNK22AbS7sjK+K8v+1KgHvt+ja4yrLmwN9rZF5xah3pGUXtgz0YZSK0j4c/+5GRA==
+use-cached@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/use-cached/-/use-cached-2.0.0.tgz#634f50b0f06d59e887df75a4800d3b379ddefa2e"
+  integrity sha512-3/jMsT5THf5OJialvABjvgnUmkevxCCSVjxIMM1DJZzJACMqKUqKBPYnEvrgxxcfGPTTqNoxADajcevlI5iKXg==
   dependencies:
     lscache "^1.3.0"
 


### PR DESCRIPTION
for lighter implementation on unspecified `remember.key` prop, it basically leverages the fact that [`use-cached v2.0`](https://github.com/woozyking/use-cached/blob/master/CHANGELOG.md#200---2020-08-05) no longer requires a cache key, in which case simply returns an unmodded hook instance.

then this branch also contains a fix for per-column initial hidden state being ignored when the column has no `accessor` (dummy column with `id`, for instance)