### PR TITLE
[G2M] Themeprovider/export

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,10 +1,10 @@
 import React from 'react'
 
-import { Theme, ThemeProvider } from '../src/index'
+import { ThemeProvider } from '../src/index'
 
 export const decorators = [
   (Story) => (
-    <ThemeProvider theme={Theme}>
+    <ThemeProvider>
       <Story />
     </ThemeProvider>
   ),

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,7 +1,6 @@
 import React from 'react'
-import { ThemeProvider } from '@material-ui/core/styles'
 
-import { Theme } from '../src/index'
+import { Theme, ThemeProvider } from '../src/index'
 
 export const decorators = [
   (Story) => (

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All non-core API/package changes (i.e. changes that do not affect the package de
 
 ## [Unreleased]
 
+### Added
+- `<ThemeProvider>` - Added custom `ThemeProvider` that uses `react-labs` theme by default.
+
 ### Fixed
 - `<Typography />` - Fixed children prop-type typo.
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Next, install the required peer dependencies:
 npm i @material-ui/core @material-ui/icons @material-ui/lab react react-dom
 ```
 
-Once you have installed all the required dependencies, wrap your application in a `<ThemeProvider>` using the default `Theme` object provided by `react-labs` as the `theme` property:
+Once you have installed all the required dependencies, wrap your application in a `<ThemeProvider>`:
 ```jsx
-import { Theme, ThemeProvider } from '@material-ui/core';
+import { ThemeProvider } from '@eqworks/react-labs';
 
 const MyApp = () => (
-  <ThemeProvider theme={Theme}>
+  <ThemeProvider>
     Hello world!
   </ThemeProvider>
 )
@@ -31,12 +31,12 @@ Now, you can start using `react-labs` components:
 ```jsx
 import { Button, Typography } from '@eqworks/react-labs'
 
-const MyApp = () => (
-  <ThemeProvider theme={Theme}>
+const MyComponent = () => (
+  <div>
     <Typography variant='h1'>Hello world!</Typography>
     <Button type='primary'>Click me!</Button>
-  </ThemeProvider>
+  </div>
 )
 ```
 
-> Note: You can override the react-labs default theme by passing a `theme` prop to `<ThemeProvider>`.<br />[Click here to find out how to create your own theme using Material UI's `createMuiTheme` method](https://material-ui.com/customization/theming/#api).
+> **Note:** You can override the `react-labs` default theme by passing a `theme` prop to `<ThemeProvider>`.<br />[Click here to find out how to create your own theme using Material UI's `createMuiTheme` method](https://material-ui.com/customization/theming/#api).

--- a/README.md
+++ b/README.md
@@ -2,53 +2,41 @@
 
 ![Master](https://github.com/EQWorks/react-labs/workflows/Master/badge.svg)
 
-`react-labs` is a collection of common React components that builds off of the [Material-UI](https://material-ui.com/) design system.
+A [React](https://reactjs.org/) user interface kit built with [Material-UI](https://material-ui.com/).
 
-## Installation
+## Getting started
 
-1. Install `react-labs`, run:
+Firstly, install `react-labs`:
 ```
 npm i @eqworks/react-labs
 ```
 
-2. Install the required peer dependencies, run:
+Next, install the required peer dependencies:
 ```
-npm i @material-ui/core @material-ui/lab @material-ui/icons react react-dom
+npm i @material-ui/core @material-ui/icons @material-ui/lab react react-dom
 ```
 
----
-
-## Usage
-
-1. Wrap your application inside a <ThemeProvider> component using the `react-labs` theme, as such:
+Once you have installed all the required dependencies, wrap your application in a `<ThemeProvider>` using the default `Theme` object provided by `react-labs` as the `theme` property:
 ```jsx
-import React from 'react'
-import ReactDOM from 'react-dom'
-import { ThemeProvider } from '@material-ui/core/styles'
+import { Theme, ThemeProvider } from '@material-ui/core';
 
-import { theme } from '@eqworks/react-labs'
-
-ReactDOM.render(
-  <ThemeProvider theme={theme}>
-    <App />
-  </ThemeProvider>,
-  document.getElementById('root'),
+const MyApp = () => (
+  <ThemeProvider theme={Theme}>
+    Hello world!
+  </ThemeProvider>
 )
 ```
 
-2. Import any component into your project:
+Now, you can start using `react-labs` components:
 ```jsx
-import { Button } from '@eqworks/react-labs'
+import { Button, Typography } from '@eqworks/react-labs'
+
+const MyApp = () => (
+  <ThemeProvider theme={Theme}>
+    <Typography variant='h1'>Hello world!</Typography>
+    <Button type='primary'>Click me!</Button>
+  </ThemeProvider>
+)
 ```
 
-3. Render the component in the DOM:
-```jsx
-export default function MyComponent() {
-  return (
-    <div>
-      <h1>This is a button</h1>
-      <Button size='medium' type='primary'>By Button</Button>
-    </div>
-  )
-}
-```
+> Note: You can override the react-labs default theme by passing a `theme` prop to `<ThemeProvider>`.<br />[Click here to find out how to create your own theme using Material UI's `createMuiTheme` method](https://material-ui.com/customization/theming/#api).

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,22 @@
 // theme
-export { ThemeProvider } from '@material-ui/core/styles'
-export { default as Theme } from './theme/index'
+import React from 'react'
+import PropTypes from 'prop-types'
+import { ThemeProvider as MUIThemeProvider } from '@material-ui/core/styles'
+import DefaultTheme from './theme'
+
+export { DefaultTheme }
+export const ThemeProvider = ({ children, theme = DefaultTheme }) => {
+  return (
+    <MUIThemeProvider theme={theme}>
+      {children}
+    </MUIThemeProvider>
+  )
+}
+
+ThemeProvider.propTypes = {
+  children: PropTypes.node,
+  theme: PropTypes.object,
+}
 
 // components
 export { default as Alert } from './alert'

--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,5 @@
 // theme
-import React from 'react'
-import PropTypes from 'prop-types'
-import { ThemeProvider as MUIThemeProvider } from '@material-ui/core/styles'
-import DefaultTheme from './theme'
-
-export { DefaultTheme }
-export const ThemeProvider = ({ children, theme = DefaultTheme }) => {
-  return (
-    <MUIThemeProvider theme={theme}>
-      {children}
-    </MUIThemeProvider>
-  )
-}
-
-ThemeProvider.propTypes = {
-  children: PropTypes.node,
-  theme: PropTypes.object,
-}
+export { DefaultTheme, ThemeProvider } from './theme'
 
 // components
 export { default as Alert } from './alert'

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 // theme
+export { ThemeProvider } from '@material-ui/core/styles'
 export { default as Theme } from './theme/index'
 
 // components

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,11 +1,15 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { ThemeProvider as MUIThemeProvider } from '@material-ui/core/styles'
 import { createMuiTheme } from '@material-ui/core/styles'
+
 import overrides from './overrides/index'
 import palette from './palette'
 import props from './props'
 import shadows from './shadows'
 import typography from './typography'
 
-const theme = createMuiTheme({
+export const DefaultTheme = createMuiTheme({
   overrides,
   palette,
   props,
@@ -13,4 +17,15 @@ const theme = createMuiTheme({
   typography,
 })
 
-export default theme
+export const ThemeProvider = ({ children, theme = DefaultTheme }) => {
+  return (
+    <MUIThemeProvider theme={theme}>
+      {children}
+    </MUIThemeProvider>
+  )
+}
+
+ThemeProvider.propTypes = {
+  children: PropTypes.node,
+  theme: PropTypes.object,
+}

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -9,7 +9,7 @@ import props from './props'
 import shadows from './shadows'
 import typography from './typography'
 
-export const DefaultTheme = createMuiTheme({
+const DefaultTheme = createMuiTheme({
   overrides,
   palette,
   props,
@@ -29,3 +29,5 @@ ThemeProvider.propTypes = {
   children: PropTypes.node,
   theme: PropTypes.object,
 }
+
+export default DefaultTheme


### PR DESCRIPTION
Update to export our own `ThemeProvider` that uses the `react-labs` theme by default. Instead of requiring `@material-ui/core` as well as importing the `react-labs` theme.

Before:
```jsx
import React from "react";
import ReactDOM from "react-dom";
import { ThemeProvider } from "@material-ui/core";
import { Theme } from "@eqworks/react-labs";

import App from "./App";

ReactDOM.render(
  <ThemeProvider theme={Theme}>
    <App />
  </ThemeProvider>,
  document.getElementById("root")
);
```

After:
```jsx
import React from "react";
import ReactDOM from "react-dom";
import { ThemeProvider } from "@eqworks/react-labs";

import App from "./App";

ReactDOM.render(
  <ThemeProvider>
    <App />
  </ThemeProvider>,
  document.getElementById("root")
);
```