### PR TITLE
[G2M]list/list-item - adjust style for status alignment on small items

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Generate tag associated release notes
         if: ${{ success() }}
-        run: npx @eqworks/release notes -v --head ${GITHUB_REF##*/} --github
+        run: npx @eqworks/release notes -v --head ${GITHUB_REF##*/} --github --skip alpha
         env:
           GITHUB_OWNER: EQWorks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All non-core API/package changes (i.e. changes that do not affect the package de
 
 ## [Unreleased]
 
+## [1.10.1] - 2020-10-07
+### Fixed
+- `<ListItem>` - Fixed status alignment style for small items.
+
 ## [1.10.0] - 2020-10-01
 ### Added
 - `<ThemeProvider>` - Added custom `ThemeProvider` that uses `react-labs` theme by default.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eqworks/react-labs",
   "private": false,
-  "version": "1.10.0",
+  "version": "1.10.1",
   "main": "dist/index.js",
   "source": "src/index.js",
   "repository": "git@github.com:EQWorks/react-labs.git",

--- a/src/list/list-item.js
+++ b/src/list/list-item.js
@@ -214,7 +214,7 @@ const ListItem = ({
           primary={itemHeading(heading, progressBar)}
           secondary={details}
         />
-        <Grid item container xs={2}>
+        <Grid item container>
           <Grid
             item
             container


### PR DESCRIPTION
- container shouldn't have `xs` attribute, which is pushing the chip out of the limits of the box when `width` is too small
<p>
<img height= '300' src='https://user-images.githubusercontent.com/53827690/95363665-bc7b0a80-089d-11eb-9ae0-43fc54764600.png' />
<img height= '300' src='https://user-images.githubusercontent.com/53827690/95363596-acfbc180-089d-11eb-9a0c-3e7ea6b0ba39.png' />