### PR TITLE
[G2M]list/list-item 

### DIFF
--- a/src/list/list-item.js
+++ b/src/list/list-item.js
@@ -18,6 +18,7 @@ import ListItemAvatar from '@material-ui/core/ListItemAvatar'
 
 const useStyles = makeStyles((theme) => {
   return {
+    item: { flex: 0 },
     font: {
       fontFamily: theme.typography.fontFamily,
       paddingLeft: theme.spacing(3),
@@ -214,12 +215,12 @@ const ListItem = ({
           primary={itemHeading(heading, progressBar)}
           secondary={details}
         />
-        <Grid item container>
+        <Grid item container className={classes.item}>
           <Grid
             item
             container
             xs={12}
-            justify="flex-start"
+            justify="flex-end"
             alignItems="flex-end"
             direction="column"
           >


### PR DESCRIPTION
- adjust style for elements to work together on small items > previous fix #130 messed up with the title and description due to the size of the elements. `flex: 0` seems to overall do the job 🙏 