### PR TITLE
[G2M]list/list-item - override default style for small items

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eqworks/react-labs",
   "private": false,
-  "version": "1.10.2-alpha",
+  "version": "1.10.3-alpha.1",
   "main": "dist/index.js",
   "source": "src/index.js",
   "repository": "git@github.com:EQWorks/react-labs.git",

--- a/src/list/list-item.js
+++ b/src/list/list-item.js
@@ -18,7 +18,8 @@ import ListItemAvatar from '@material-ui/core/ListItemAvatar'
 
 const useStyles = makeStyles((theme) => {
   return {
-    item: { flex: 0 },
+    item: { flex: 1 },
+    itemText: { flex: '2 1 0%' },
     font: {
       fontFamily: theme.typography.fontFamily,
       paddingLeft: theme.spacing(3),
@@ -214,8 +215,9 @@ const ListItem = ({
         <ListItemText
           primary={itemHeading(heading, progressBar)}
           secondary={details}
+          classes={{ root: classes.itemText }}
         />
-        <Grid item container className={classes.item}>
+        <Grid item container classes={{ item: classes.item }}>
           <Grid
             item
             container


### PR DESCRIPTION
based on #131 approach works but should be overriding MUI elements default style. 
Added flex to `ListItemText` so it won't wrap too far behind chip. It's a balance we have to choose between title VS chip & other elements