### PR TITLE
[G2M]list/list-item - add the option to style timeStatus typography

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 All non-core API/package changes (i.e. changes that do not affect the package delivery to the end users) will be noted under the **Non-Core** category.
 
 ## [Unreleased]
+### Fixed
+- `<ListItem>` - Another fix in timeStatus alignment/style for small items in harmony with the typography
+
+### Added
+- `<ListItem>` - `timeStatusStyle` key:value can be added to `data` param to apply style to the timeStatus element, now inside
+
+```
+<Typography
+  component={'span'}
+  {...timeStatusStyle}
+>
+  {timeStatus}
+</Typography>
+```
 
 ## [1.10.1] - 2020-10-07
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eqworks/react-labs",
   "private": false,
-  "version": "1.10.3-alpha.1",
+  "version": "1.10.3-alpha.2",
   "main": "dist/index.js",
   "source": "src/index.js",
   "repository": "git@github.com:EQWorks/react-labs.git",

--- a/src/list/list-item.js
+++ b/src/list/list-item.js
@@ -15,6 +15,7 @@ import LinearProgress from '@material-ui/core/LinearProgress'
 import ListItemText from '@material-ui/core/ListItemText'
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
 import ListItemAvatar from '@material-ui/core/ListItemAvatar'
+import { Typography } from '../index'
 
 const useStyles = makeStyles((theme) => {
   return {
@@ -119,6 +120,7 @@ const ListItem = ({
   heading,
   details,
   timeStatus,
+  timeStatusStyle,
   progress,
   progressBar,
   chip,
@@ -240,14 +242,22 @@ const ListItem = ({
             {timeStatus && (
               <div className={classes.timeStatus}>
                 {progress ? (
-                  <FiberManualRecord
-                    className={clsx({
-                      [classes.complete]: progress === 'complete',
-                      [classes.inProgress]: progress === 'incomplete',
-                    })}
-                  />
+                  <>
+                    <FiberManualRecord
+                      className={clsx({
+                        [classes.complete]: progress === 'complete',
+                        [classes.inProgress]: progress === 'incomplete',
+                      })}
+                    />
+                  &nbsp;&nbsp;
+                  </>
                 ) : null}
-                &nbsp;&nbsp;{timeStatus}
+                <Typography
+                  component='span'
+                  {...timeStatusStyle}
+                >
+                  {timeStatus}
+                </Typography>
               </div>
             )}
           </Grid>
@@ -293,6 +303,7 @@ ListItem.propTypes = {
   selected: PropTypes.bool,
   button: PropTypes.bool,
   timeStatus: PropTypes.string,
+  timeStatusStyle: PropTypes.object,
   progress: PropTypes.string,
   progressBar: PropTypes.number,
   chip: PropTypes.string,
@@ -318,6 +329,7 @@ ListItem.defaultProps = {
   selected: false,
   button: false,
   timeStatus: '',
+  timeStatusStyle: {},
   progress: '',
   progressBar: 0,
   chip: '',

--- a/stories/list.stories.js
+++ b/stories/list.stories.js
@@ -116,10 +116,10 @@ const leftData = defaultData.map((item, i) => {
 })
 const rightData = defaultData.map((item, i) => {
   const newFields = [
-    { chip: 'Marketplace', chipColor: '#6fcf97', timeStatus: '30m' },
-    { chip: 'Builder', chipColor: '#f2c94c', timeStatus: '2h' },
-    { chip: 'Builder', chipColor: '#f2c94c', timeStatus: '30m' },
-    { chip: 'Segment', chipColor: '#56ccf2', timeStatus: '4h' },
+    { chip: 'Marketplace', chipColor: '#6fcf97', timeStatus: '30m', progress: 'incomplete' },
+    { chip: 'Builder', chipColor: '#f2c94c', timeStatus: '2h', progress: 'complete' },
+    { chip: 'Builder', chipColor: '#f2c94c', timeStatus: '30m', timeStatusStyle: { style: { color: 'red', textDecoration: 'line-through' } } },
+    { chip: 'Segment', chipColor: '#56ccf2', timeStatus: '4h', timeStatusStyle: { variant: 'subtitle1', style: { textDecoration: 'underline overline', fontWeight: 'bold' } } },
   ]
   const newItem = {
     ...item,


### PR DESCRIPTION
@SamSverko 🚀 

an attempt to make list-item more suitable to our needs, I now added the option to style some text so I can achieve something similar to [this design](https://zpl.io/aBxnOpK)  for marketplace where I need a line through where there will be price.
DESIGN 
<img width="492" alt="Screen Shot 2020-10-09 at 3 32 04 PM" src="https://user-images.githubusercontent.com/53827690/95624304-a6f41500-0a44-11eb-88aa-6068e336c954.png">
REACT_LABS STORIES
![Screen Shot 2020-10-09 at 3 30 54 PM](https://user-images.githubusercontent.com/53827690/95624171-6c8a7800-0a44-11eb-8c22-8988a2dc43ec.png)
