### PR TITLE
[G2M] Button - remove children requirement

### DIFF
--- a/src/button.js
+++ b/src/button.js
@@ -44,7 +44,7 @@ Button.propTypes = {
   /**
     * The content of the button.
   */
-  children: PropTypes.string.isRequired,
+  children: PropTypes.string,
   /**
     * Toggle loading style of component.
   */


### PR DESCRIPTION
Closes #149

During transition in poi-manage from semantic-ui-react components to react-labs components, icon buttons were used and we realized that empty strings were needed to be included as well.
https://github.com/EQWorks/poi-manage/pull/40/commits/2a56f68df833832a0e6e60f58ede69e4784baaf1#r542786667