### PR TITLE
[G2M] [2.0] Remove MUIChip lowercase textTransform

### DIFF
--- a/src/theme/overrides/MuiChip.js
+++ b/src/theme/overrides/MuiChip.js
@@ -1,7 +1,0 @@
-const MuiChip = {
-  root: {
-    textTransform: 'lowercase',
-  },
-}
-
-export default MuiChip

--- a/src/theme/overrides/index.js
+++ b/src/theme/overrides/index.js
@@ -1,12 +1,10 @@
 import MuiButton from './MuiButton'
 import MuiCard from './MuiCard'
-import MuiChip from './MuiChip'
 import MuiLink from './MuiLink'
 
 const overrides = {
   MuiButton,
   MuiCard,
-  MuiChip,
   MuiLink,
 }
 


### PR DESCRIPTION
**Issue:**
Currently the Chip component can only display lowercase labels. 

**Solution:** 
Delete MUIChip file under theme folder with the `textTransform: 'lowercase'` prop.