### PR TITLE
[G2M] tabs - add forwardRef to use with drawers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eqworks/react-labs",
   "private": false,
-  "version": "1.12.1-alpha.4",
+  "version": "1.12.1-alpha.5",
   "main": "dist/index.js",
   "source": "src/index.js",
   "repository": "git@github.com:EQWorks/react-labs.git",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,8 @@
+import withRef from './with-ref'
+import TabPanels from './tab-panels'
+
+const TabPanelsWithRef = withRef(TabPanels)
+
 // untouched material-ui
 export { default as FormControl } from '@material-ui/core/FormControl'
 export { default as FormControlLabel } from '@material-ui/core/FormControlLabel'
@@ -29,6 +34,8 @@ export { default as TabPanels } from './tab-panels'
 export { default as TextField } from './text-field'
 export { default as Typography } from './typography'
 export { default as WidgetStats } from './widget-stats'
+export { default as withRef } from './with-ref'
+export { TabPanelsWithRef }
 
 // deprecated
 export { default as DataTable } from './deprecated/data-table' // deprecated by Table

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import withRef from './with-ref'
 import TabPanels from './tab-panels'
 
 const TabPanelsWithRef = withRef(TabPanels)
+TabPanelsWithRef.displayName= 'TabPanelsWithRef'
 
 // untouched material-ui
 export { default as FormControl } from '@material-ui/core/FormControl'

--- a/src/tab-panels.js
+++ b/src/tab-panels.js
@@ -10,10 +10,15 @@ const useStyles = makeStyles({
     flexGrow: 1,
     display: 'flex',
   },
+  horizontal: { position: 'relative' },
 })
 
 const TabPanel = ({ children, value, index }) => value === index && children
 
+/**
+ * can be used with `withRef` HOC to append a drawer to the tabChild | used in ML
+ * the `forwardRef` prop needs to be an array of references of the same size as the the tabChildren array
+*/
 const TabPanels = ({
   tabIndex,
   tabLabels,
@@ -24,6 +29,7 @@ const TabPanels = ({
   TabProps,
   onChange: controlledOnChange,
   value: controlledValue,
+  forwardRef: tabsRefs,
 }) => {
   const classes = useStyles()
   const [value, setValue] = useState(tabIndex)
@@ -52,9 +58,11 @@ const TabPanels = ({
       </TabsComponent>
       {tabChildren.length > 0 &&
         tabChildren.map((child, i) => (
-          <TabPanel key={i} value={controlledValue !== null ? controlledValue: value} index={i}>
-            {child.content || child}
-          </TabPanel>
+          <div key={i} ref={tabsRefs[i]} className={classes.horizontal}>
+            <TabPanel value={controlledValue !== null ? controlledValue: value} index={i}>
+              {child.content || child}
+            </TabPanel>
+          </div>
         ))}
     </div>
   )
@@ -88,6 +96,7 @@ TabPanels.propTypes = {
     PropTypes.string,
     PropTypes.number,
   ]),
+  forwardRef: PropTypes.array,
 }
 
 TabPanels.defaultProps = {
@@ -100,6 +109,7 @@ TabPanels.defaultProps = {
   TabProps: {},
   onChange: () => {},
   value: null,
+  forwardRef: [],
 }
 
 export default TabPanels

--- a/src/tab-panels.js
+++ b/src/tab-panels.js
@@ -16,8 +16,8 @@ const useStyles = makeStyles({
 const TabPanel = ({ children, value, index }) => value === index && children
 
 /**
- * can be used with `withRef` HOC to append a drawer to the tabChild | used in ML
- * the `forwardRef` prop needs to be an array of references of the same size as the the tabChildren array
+ * can be used with `withRef` HOC to append a drawer to the tabChild | used in ML.
+ * The `forwardRef` prop needs to be an array of references of the same size as the the tabChildren array
 */
 const TabPanels = ({
   tabIndex,

--- a/src/with-ref.js
+++ b/src/with-ref.js
@@ -1,0 +1,8 @@
+import React, { forwardRef } from 'react'
+
+const withRef = (Component) => {
+  const componentWithRef = (props, ref) => (<Component forwardRef={ref} {...props}/>)
+  return forwardRef(componentWithRef)
+}
+
+export default withRef

--- a/stories/tab-panels.stories.js
+++ b/stories/tab-panels.stories.js
@@ -115,8 +115,6 @@ export default {
 }
 
 const Template = (args) => <TabPanels {...args} />
-const TemplateRef = (args) => <TabPanelsWithRef {...args} /> // const TabPanelsWithRef = withRef(TabPanels)
-
 export const Default = Template.bind({})
 
 // ===
@@ -125,7 +123,15 @@ export const Alternate = Template.bind({})
 
 export const Vertical = Template.bind({})
 
-export const WithRef = TemplateRef.bind({})
+// const TabPanelsWithRef = withRef(TabPanels)
+export const WithRef = () => (<TabPanelsWithRef
+  {...{ customTab,
+    customTabs: customTabs,
+    tabChildren: tabsWithRefArr,
+    tabLabels: labelArr,
+  }}
+  ref={tabsRefs}
+/>)
 
 Alternate.args = {
   customTab: customTab,
@@ -137,11 +143,4 @@ Vertical.args = {
   customTabs: customVerTabs,
   TabsProps: { orientation: 'vertical' },
   tabLabels: labelVerArr,
-}
-
-WithRef.args = {
-  customTab,
-  customTabs: customTabs,
-  forwardRef: tabsRefs || [],
-  tabChildren: tabsWithRefArr,
 }

--- a/stories/tab-panels.stories.js
+++ b/stories/tab-panels.stories.js
@@ -1,12 +1,49 @@
-import React from 'react'
+import React, { createRef } from 'react'
 
 import BuildIcon from '@material-ui/icons/Build'
 import BookmarksIcon from '@material-ui/icons/Bookmarks'
+import Drawer from '@material-ui/core/Drawer'
 
-import { TabPanels } from '../src/index'
+import { TabPanels, TabPanelsWithRef } from '../src/index'
+// import { withRef } from '../src/index'
 
 const labelArr = ['Tab-1', 'Tab-2', 'Tab-3']
 const tabsArr = ['Tab-1: children', 'Tab-2: children', '3: something here']
+
+const tabsRefs = tabsArr.map(() => createRef(null)) // same number of refs as tabs
+const tabsWithRefArr = tabsArr.map((child, i) => {
+  return (
+    <div key={i}>
+      <Drawer
+        open
+        anchor='top'
+        variant='persistent'
+        elevation={0}
+        PaperProps={{
+          style: {
+            position: 'absolute',
+            height: 100,
+            border: '2px solid black',
+          },
+        }}
+        ModalProps={{
+          container: tabsRefs[i],
+          style: { position: 'absolute' },
+        }}
+      >
+        <div style={{
+          height: (i + 10) * 10,
+          backgroundColor: `rgb(${i}50, ${i}50, ${i}50)`,
+        }}>
+          drawer content from {child}
+        </div>
+      </Drawer>
+      <p style={{ paddingTop: 150, height: '100px', textAlign: 'center', margin: 0 }}>
+        {child} context
+      </p>
+    </div>
+  )
+})
 
 const labelVerArr = [
   <BuildIcon key='Views' onClick={() => console.log('Clicked Views.')} />,
@@ -78,6 +115,7 @@ export default {
 }
 
 const Template = (args) => <TabPanels {...args} />
+const TemplateRef = (args) => <TabPanelsWithRef {...args} /> // const TabPanelsWithRef = withRef(TabPanels)
 
 export const Default = Template.bind({})
 
@@ -86,6 +124,8 @@ export const Default = Template.bind({})
 export const Alternate = Template.bind({})
 
 export const Vertical = Template.bind({})
+
+export const WithRef = TemplateRef.bind({})
 
 Alternate.args = {
   customTab: customTab,
@@ -97,4 +137,11 @@ Vertical.args = {
   customTabs: customVerTabs,
   TabsProps: { orientation: 'vertical' },
   tabLabels: labelVerArr,
+}
+
+WithRef.args = {
+  customTab,
+  customTabs: customTabs,
+  forwardRef: tabsRefs || [],
+  tabChildren: tabsWithRefArr,
 }


### PR DESCRIPTION
**context:** ml-ui usecase to append a drawer anchored on the child component of that tab

**quirks**: commit 08c5198 uses storybook syntax BUT that is misleading. Under the hood Storybook seems to be merging the `WithRef.args` with default args of the component and then passing it to the component again. This means that we'd have to actually declare `forwardRef` not to get lost in translation. This gives the wrong idea that the array or references needs to be passed inside `forwardRef` when actual implementation needs it inside `ref`. So I went _tru_ with 5a2ead7 story syntax

![image](https://user-images.githubusercontent.com/53827690/104650594-6da2f500-5684-11eb-854a-5b3a22c774eb.png)
